### PR TITLE
add one more test case with RepeatedMethodCall

### DIFF
--- a/src/main/java/core/basesyntax/WorkWithFile.java
+++ b/src/main/java/core/basesyntax/WorkWithFile.java
@@ -1,7 +1,6 @@
 package core.basesyntax;
 
 public class WorkWithFile {
-
     public void getStatistic(String fromFileName, String toFileName) {
 
     }

--- a/src/test/java/core/basesyntax/WorkWithFileTest.java
+++ b/src/test/java/core/basesyntax/WorkWithFileTest.java
@@ -70,6 +70,19 @@ public class WorkWithFileTest {
         Assert.assertEquals(expectedResult, actualResult);
     }
 
+    @Test
+    public void getStatisticAboutBananaRepeatedMethodCall() {
+        workWithFile.getStatistic("banana.csv", BANANA_RESULT_FILE);
+        workWithFile.getStatistic("banana.csv", BANANA_RESULT_FILE);
+
+        String actualResult = readFromFile(BANANA_RESULT_FILE).trim();
+        String expectedResult = "supply,491" + System.lineSeparator()
+            + "buy,293" + System.lineSeparator()
+            + "result,198";
+        Assert.assertEquals("Calling the getStatistic() method repeatedly returned incorrect results.",
+            expectedResult, actualResult);
+    }
+
     private String readFromFile(String fileName) {
         try {
             return Files.readString(Path.of(fileName));


### PR DESCRIPTION
The common mistake of students is to store some data in the class fields. 
It is a mistake because, their class becomes stateful, and we can't actually call the ```getStatistic()``` method twice. 